### PR TITLE
fix: Remove deprecated `bottle :unneeded`

### DIFF
--- a/commit-colors.rb
+++ b/commit-colors.rb
@@ -6,7 +6,6 @@ class CommitColors < Formula
   desc "See a lovely color swatch in your terminal every time you author a commit."
   homepage "https://github.com/sparkbox/commit-colors"
   version "2.0.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Remove `bottle :unneeded` from brew formula.

`bottle :unneeded` now provokes a warning from Homebrew: `Warning: Calling bottle :unneeded is deprecated! There is no replacement.`

Homebrew apparently deprecated `bottle :unneeded` in [Homebrew/brew@f65d525](https://github.com/Homebrew/brew/commit/f65d525693a45c8e4c2ebc1452080f08c363ee15)
